### PR TITLE
Optional SSL Cert Verify and YAML support

### DIFF
--- a/rest-api-python-scripts/central_lib/README.md
+++ b/rest-api-python-scripts/central_lib/README.md
@@ -93,9 +93,9 @@ ssl_verify: true
 
 **Please Note:**
 
-- Providing Aruba Central details in clear text in production might be a security risk. Extend "ArubaCentralBase" class and implement your token management mechanism for secure token management.
+    - Providing Aruba Central details in clear text in production might be a security risk. Extend "ArubaCentralBase" class and implement your token management mechanism for secure token management.
 
-- If previously generated access token is not used over a period of 2 weeks, they will be revoked by Aruba Central. In this case, either provide new token or provide user credentials to generate a new token.
+    - If previously generated access token is not used over a period of 2 weeks, they will be revoked by Aruba Central. In this case, either provide new token or provide user credentials to generate a new token.
 
 2. Create instance of `ArubaCentralBase` class by initializing the required variables.
 

--- a/rest-api-python-scripts/central_lib/README.md
+++ b/rest-api-python-scripts/central_lib/README.md
@@ -1,8 +1,8 @@
 # Aruba Central Python Library
 
-This section consists of information on how to use the `central_lib` Python package to get started with automation with Aruba Central in a breeze. 
+This section consists of information on how to use the `central_lib` Python package to get started with automation with Aruba Central in a breeze.
 
-This library manages creation of API access token using OAUTH, storing the token for re-use and makes API calls using Python requests package. Upon receiving *HTTP 401 Unauthorized error*, the library will attempt to refresh stored token, update the storage with renewed token and retry the failed API request. 
+This library manages creation of API access token using OAUTH, storing the token for re-use and makes API calls using Python requests package. Upon receiving *HTTP 401 Unauthorized error*, the library will attempt to refresh stored token, update the storage with renewed token and retry the failed API request.
 
 ### Requirements
 Follow this part of the guide to install [requirements](/rest-api-python-scripts#getting-started-with-automation-using-aruba-central-api) needed for this library.
@@ -11,13 +11,17 @@ Follow this part of the guide to install [requirements](/rest-api-python-scripts
 
 Provided below is the snippet of code from *central_lib_usage.py* python script. Using the central_lib consists of four simple steps,
 
-1. Fill Aruba Central information in inventory JSON file as shown in `input_credentials.json` file. 
+1. Fill Aruba Central information in inventory JSON file as shown in `input_credentials.json` file.
 
    - 'lib_path': Path to *central_lib* folder
 
    - 'central_info': As provided in earlier sections, obtain these required variables and update the file.
 
-   - 'token_store': Only type 'local' token storage and accessing of stored token for re-use is implemented. 'path' is the local file system path where a JSON file will be created to store access token and refresh token information. 
+   - 'token_store': Only type 'local' token storage and accessing of stored token for re-use is implemented. 'path' is the local file system path where a JSON file will be created to store access token and refresh token information.
+
+   - 'ssl_verify': Defaults to *true* to verify SSL certs. To disable set SSL cert validation set to *false*
+
+Inventory File in *JSON* format
 
 ```json
 {
@@ -33,12 +37,31 @@ Provided below is the snippet of code from *central_lib_usage.py* python script.
   "token_store": {
     "type": "local",
     "path": "temp"
-  }
+  },
+  "ssl_verify": true
 }
 ```
 
-Optionally, central_lib works with just *access_token* variable instead of providing information of concern. It is helpful for user applications which doesn't store Aruba Central account credentials and manage tokens (creation, storage for re-use and refresh) externally for security. Refer the `central_lib/input_token_only.json` file.
+Inventory File in *YAML* format
 
+```yaml
+lib_path: "../"
+central_info:
+  username: "<aruba-central-account-username>"
+  password: "<aruba-central-account-password>"
+  client_id: "<api-gateway-client-id>"
+  client_secret: "<api-gateway-client-secret>"
+  customer_id: "<aruba-central-customer-id>"
+  base_url: "<api-gateway-domain-url>"
+token_store:
+  type: "local"
+  path: "temp"
+ssl_verify: true
+```
+
+Optionally, central_lib works with just *access_token* variable instead of providing user credentials. It is helpful for user applications which doesn't store Aruba Central account credentials and manage tokens (creation, storage for re-use and refresh) externally for security. Refer the `central_lib/input_token_only.json` file.
+
+Inventory File in *JSON* format
 ```json
 {
  "lib_path": "../",
@@ -47,11 +70,32 @@ Optionally, central_lib works with just *access_token* variable instead of provi
                 "token": {
                   "access_token": "<api-gateway-access-token>"
                 }
-               }
+              },
+ "ssl_verify": true
 }
 ```
+Inventory File in *YAML* format
 
-**Please Note: Providing Aruba Central details via JSON file in production may be vulnerable to security attack. Extend "ArubaCentralBase" class and implement your token management mechanism for secure token management.**
+The commented key-value pairs are optional and if provided expired token will be refreshed by the script.
+
+```YAML
+lib_path: "../"
+central_info:
+  base_url: "<api-gateway-domain-url>"
+  # client_id: "<api-gateway-client-id>"
+  # client_secret: "<api-gateway-client-secret>"
+  # customer_id: "<aruba-central-customer-id>"
+  token:
+    access_token: <api-gateway-access-token>
+    # refresh_token: <api-gateway-refresh-token>
+ssl_verify: true
+```
+
+**Please Note:**
+
+- Providing Aruba Central details in clear text in production might be a security risk. Extend "ArubaCentralBase" class and implement your token management mechanism for secure token management.
+
+- If previously generated access token is not used over a period of 2 weeks, they will be revoked by Aruba Central. In this case, either provide new token or provide user credentials to generate a new token.
 
 2. Create instance of `ArubaCentralBase` class by initializing the required variables.
 
@@ -61,12 +105,13 @@ Optionally, central_lib works with just *access_token* variable instead of provi
 
     # Read input JSON inventory file
     input_args = get_file_content(args.inventory)
-    
+
     # Connection object for Aruba Central as 'central'
     central_info = input_args["central_info"]
     token_store = input_args["token_store"]
-     
-    central = ArubaCentralBase(central_info, token_store)
+    ssl_verify = input_args["ssl_verify"]
+
+    central = ArubaCentralBase(central_info, token_store, ssl_verify=ssl_verify)
 ```
 
 3. Define variables for API call using some of these variables [apiPath, apiMethod, apiParams, apiData, headers and files]. *apiPath* and *apiMethod* are mandatory, other variables are optional based on Aruba Central API endpoint requirement. Execute the API Request by calling *command* function using *ArubaCentralBase* instance object created in the previous step.
@@ -82,18 +127,18 @@ Optional *files* variable accepted by *command* function is a file pointer to a 
         "limit": 20,
         "offset": 0
     }
-    
+
     # Making an API call
     resp = central.command(apiMethod=apiMethod, apiPath=apiPath,
                            apiParams=apiParams)
-                           
+
     # Printing response of the API call
     pprint(resp)
 
     # REPEAT WITH NEW API CALLS HERE
     # ...
     # ...
-    
+
 ```
 
 4. Execute the script.

--- a/rest-api-python-scripts/central_lib/README.md
+++ b/rest-api-python-scripts/central_lib/README.md
@@ -92,10 +92,7 @@ ssl_verify: true
 ```
 
 **Please Note:**
-
-    - Providing Aruba Central details in clear text in production might be a security risk. Extend "ArubaCentralBase" class and implement your token management mechanism for secure token management.
-
-    - If previously generated access token is not used over a period of 2 weeks, they will be revoked by Aruba Central. In this case, either provide new token or provide user credentials to generate a new token.
+Providing Aruba Central details in clear text in production might be a security risk. Extend "ArubaCentralBase" class and implement your token management mechanism for secure token management.
 
 2. Create instance of `ArubaCentralBase` class by initializing the required variables.
 

--- a/rest-api-python-scripts/central_lib/input_credentials.json
+++ b/rest-api-python-scripts/central_lib/input_credentials.json
@@ -1,15 +1,16 @@
 {
  "lib_path": "../",
  "central_info": {
-                "username": "<aruba-central-account-username>",
-                "password": "<aruba-central-account-password>",
-                "client_id": "<api-gateway-client-id>",
-                "client_secret": "<api-gateway-client-secret>",
-                "customer_id": "<aruba-central-customer-id>",
-                "base_url": "<api-gateway-domain-url>"
-              },
+                  "username": "<aruba-central-account-username>",
+                  "password": "<aruba-central-account-password>",
+                  "client_id": "<api-gateway-client-id>",
+                  "client_secret": "<api-gateway-client-secret>",
+                  "customer_id": "<aruba-central-customer-id>",
+                  "base_url": "<api-gateway-domain-url>"
+                 },
   "token_store": {
     "type": "local",
     "path": "temp"
-  }
+  },
+  "ssl_verify": true
 }

--- a/rest-api-python-scripts/central_lib/input_credentials.yaml
+++ b/rest-api-python-scripts/central_lib/input_credentials.yaml
@@ -1,0 +1,12 @@
+lib_path: "../"
+central_info:
+  username: "<aruba-central-account-username>"
+  password: "<aruba-central-account-password>"
+  client_id: "<api-gateway-client-id>"
+  client_secret: "<api-gateway-client-secret>"
+  customer_id: "<aruba-central-customer-id>"
+  base_url: "<api-gateway-domain-url>"
+token_store:
+  type: "local"
+  path: "temp"
+ssl_verify: true

--- a/rest-api-python-scripts/central_lib/input_token_only.json
+++ b/rest-api-python-scripts/central_lib/input_token_only.json
@@ -5,5 +5,6 @@
                 "token": {
                   "access_token": "<api-gateway-access-token>"
                 }
-               }
+              },
+  "ssl_verify": true
 }

--- a/rest-api-python-scripts/central_modules/README.md
+++ b/rest-api-python-scripts/central_modules/README.md
@@ -1,6 +1,6 @@
 # MODULE DOCUMENTATION
 
-This folder contains modules that can be leveraged to automate time consuming and repetitive tasks without having to write any program. Each directory within 'central_modules' folder is a module and the name of the folder is the considered the *module_name*. All modules follow same execution and input structure. 
+This folder contains modules that can be leveraged to automate time consuming and repetitive tasks without having to write any program. Each directory within 'central_modules' folder is a module and the name of the folder is the considered the *module_name*. All modules follow same execution and input structure.
 
 ### Requirements
 These modules are developed based on **central_lib** package as provided in this repository. Follow this part of the guide to install [requirements](/rest-api-python-scripts#getting-started-with-automation-using-aruba-central-api) needed for the *central_lib*.
@@ -10,9 +10,9 @@ Also provide path of the central_lib in the inventory file.
 ### Execute Module
 Command to Execute a module
 ```
-python3 execute_module.py -i=input_credentials.json -m=rename_ap/task_input.json 
+python3 execute_module.py -i=input_credentials.json -m=rename_ap/task_input.json
 ```
-where 
+where
 - argument `-m / --moduleinput` accepts a file name which varies for every module.
 - argument `-i / --inventory` accepts a filename which contains Aruba Central information required by the script.
 
@@ -28,13 +28,17 @@ Arguments:
 ```
 
 ### Inventory File
-Fill Aruba Central information in inventory JSON file as shown in `input_credentials.json` file. 
+Fill Aruba Central information in inventory JSON file as shown in `input_credentials.json` file.
 
 - 'lib_path': Path to *central_lib* folder
 
 - 'central_info': As provided in earlier sections, obtain these required variables and update the file.
 
-- 'token_store': Only type 'local' token storage and accessing of stored token for re-use is implemented. 'path' is the local file system path where a JSON file will be created to store access token and refresh token information. 
+- 'token_store': Only type 'local' token storage and accessing of stored token for re-use is implemented. 'path' is the local file system path where a JSON file will be created to store access token and refresh token information.
+
+- 'ssl_verify': Defaults to *true* to verify SSL certs. To disable set SSL cert validation set to *false*
+
+Inventory File in *JSON* format
 
 ```json
 {
@@ -50,12 +54,31 @@ Fill Aruba Central information in inventory JSON file as shown in `input_credent
   "token_store": {
     "type": "local",
     "path": "temp"
-  }
+  },
+  "ssl_verify": true
 }
 ```
 
-Optionally, central_lib works with just *access_token* variable instead of providing information of concern. It is helpful for user applications which doesn't store Aruba Central account credentials and manage tokens (creation, storage for re-use and refresh) externally for security. Refer the `central_lib/input_token_only.json` file.
+Inventory File in *YAML* format
 
+```yaml
+lib_path: "../"
+central_info:
+  username: "<aruba-central-account-username>"
+  password: "<aruba-central-account-password>"
+  client_id: "<api-gateway-client-id>"
+  client_secret: "<api-gateway-client-secret>"
+  customer_id: "<aruba-central-customer-id>"
+  base_url: "<api-gateway-domain-url>"
+token_store:
+  type: "local"
+  path: "temp"
+ssl_verify: true
+```
+
+Optionally, central_lib works with just *access_token* variable instead of providing user credentials. It is helpful for user applications which doesn't store Aruba Central account credentials and manage tokens (creation, storage for re-use and refresh) externally for security. Refer the `central_lib/input_token_only.json` file.
+
+Inventory File in *JSON* format
 ```json
 {
  "lib_path": "../",
@@ -64,8 +87,25 @@ Optionally, central_lib works with just *access_token* variable instead of provi
                 "token": {
                   "access_token": "<api-gateway-access-token>"
                 }
-               }
+              },
+ "ssl_verify": true
 }
+```
+Inventory File in *YAML* format
+
+The commented key-value pairs are optional and if provided expired token will be refreshed by the script.
+
+```YAML
+lib_path: "../"
+central_info:
+  base_url: "<api-gateway-domain-url>"
+  # client_id: "<api-gateway-client-id>"
+  # client_secret: "<api-gateway-client-secret>"
+  # customer_id: "<aruba-central-customer-id>"
+  token:
+    access_token: <api-gateway-access-token>
+    # refresh_token: <api-gateway-refresh-token>
+ssl_verify: true
 ```
 
 ### Module Input File
@@ -78,6 +118,8 @@ Each module accepts a set of input defined under in the moduleinput JSON file.
 Please Note: Multiple tasks can be executed by adding additional block within tasks list
 
 Sample module input file with single task
+
+**JSON:**
 
 ```json
 {
@@ -93,7 +135,18 @@ Sample module input file with single task
 }
 ```
 
-Sample module input file with multiple tasks. Tasks with different module names can be called from single execution. In addition, same module name can be used in multiple tasks. 
+**YAML:**
+
+```yaml
+tasks:
+  - <module_name_1>:
+      description: "TASK-1"
+      ...: "..."
+      ...: "..."
+```
+Sample module input file with multiple tasks. Tasks with different module names can be called from single execution. In addition, same module name can be used in multiple tasks.
+
+**JSON:**
 
 ```json
 {
@@ -116,6 +169,20 @@ Sample module input file with multiple tasks. Tasks with different module names 
 }
 ```
 
+**YAML:**
+
+```yaml
+tasks:
+  - <module_name_1>:
+      description: "TASK-1"
+      ...: "..."
+      ...: "..."
+  - <module_name_2>:
+      description: "TASK-2"
+      ...: "..."
+      ...: "..."
+```
+
 ### Example Module Execution
 
 As an example, let's look at how to rename hundreds of Access Points (IAPs) in a single task from module `rename_ap`.
@@ -130,6 +197,8 @@ BBBBBBBBBB,AP2,0.0.0.0
 
 2. Create an input JSON file for the rename_ap module.
 
+**JSON:**
+
 ```json
 {
   "tasks": [
@@ -142,10 +211,17 @@ BBBBBBBBBB,AP2,0.0.0.0
 }
 ```
 
+**YAML:**
+
+```yaml
+tasks:
+  - rename_ap:
+      ap_info: "rename_ap/csv_file.csv"
+```
 3. Execute the module
 
 ```bash
-python3 execute_module.py -i=input_credentials.json -m=rename_ap/task_input.json 
+python3 execute_module.py -i=input_credentials.json -m=rename_ap/task_input.json
 ```
 
 4. Sample Output:
@@ -188,6 +264,9 @@ In this section, let's look at list of available modules, its purpose and usage.
 This module is built to make any HTTP request Aruba Central has to offer. It basically makes an API call and prints the output on the screen. Multiple tasks can be stacked to create a simple automation workflow that doesn't need input and output parsing.
 
 Input Paramerts to tasks list is as follow,
+
+**JSON:**
+
 ```json
 {
   "tasks": [
@@ -202,45 +281,51 @@ Input Paramerts to tasks list is as follow,
         "api_headers": "<optional_HTTP_headers>"     
       }
     }
+  ]
+}
+```
+
+**YAML:**
+```yaml
+tasks:
+  - api_request:
+      description: "[Optional] Provide any description for documentation"
+      api_path: "<required_apiPath>"
+      api_method: "<required_apiMethod>"
+      api_params: "<optional_query_params>"
+      api_data: "<optional_HTTP_data>"
+      api_files: "<optional_filepath_for_fileupload>"
+      api_headers: "<optional_HTTP_headers>"
 ```
 
 Sample Module Input File that Gets list of groups and Creates a new group.
-```json  
-{
-  "tasks": [
-    {
-      "api_request": {
-        "description": "Get group list",
-        "api_path": "/configuration/v2/groups",
-        "api_params": {
-          "limit": 20,
-          "offset": 0
-        },
-        "api_method": "GET"
-      }
-    },
-    {
-      "api_request": {
-        "description": "Create a template group named auto-group-py",
-        "api_path": "/configuration/v2/groups",
-        "api_method": "POST",
-        "api_data": {
-          "group": "auto-group-py",
-          "group_attributes": {
-            "group_password": "admin1234",
-            "template_info": {
-              "Wired": true,
-              "Wireless": true
-            }
-          }
-        }
-      }
-    }]}
+
+```yaml  
+tasks:
+  - api_request:
+      description: "Get group list"
+      api_path: "/configuration/v2/groups"
+      api_params:
+        limit: 20
+        offset: 0
+      api_method: "GET"
+
+  - api_request:
+      description: "Create a template group named auto-group-py"
+      api_path: "/configuration/v2/groups"
+      api_method: "POST"
+      api_data:
+        group: "auto-group-py"
+        group_attributes:
+          group_password: "admin1234"
+          template_info:
+            Wired: true
+            Wireless: true
 ```
 
 ### 2. rename_ap
 
-The purpose of this module is to rename hundreds of IAPs in Aruba Central via automation. A `.csv` file should be created with columns ["serial_number", "hostname", ip_address"] in the following format. An IAP will be identified based on the serial number and an API call will be made to rename the IAP. 
+The purpose of this module is to rename hundreds of IAPs in Aruba Central via automation. A `.csv` file should be created with columns ["serial_number", "hostname", ip_address"] in the following format. An IAP will be identified based on the serial number and an API call will be made to rename the IAP.
 
 **Please Note: If you are conscious about Aruba Central API usage limit, one API call per IAP is required.**
 
@@ -254,14 +339,8 @@ The *ip_address* should be set to "0.0.0.0" if the Access Point gets ip_address 
 
 Sample module input JSON file as follows,
 
-```json
-{
-  "tasks": [
-    {
-      "rename_ap": {
-        "ap_info": "<csv_filename_with_filepath>"
-      }
-    }
-  ]
-}
+```yaml
+tasks:
+  - rename_ap:
+      ap_info: "<csv_filename_with_filepath>"
 ```

--- a/rest-api-python-scripts/central_modules/README.md
+++ b/rest-api-python-scripts/central_modules/README.md
@@ -119,7 +119,7 @@ Please Note: Multiple tasks can be executed by adding additional block within ta
 
 Sample module input file with single task
 
-**JSON:**
+JSON:
 
 ```json
 {
@@ -135,7 +135,7 @@ Sample module input file with single task
 }
 ```
 
-**YAML:**
+YAML:
 
 ```yaml
 tasks:
@@ -146,7 +146,7 @@ tasks:
 ```
 Sample module input file with multiple tasks. Tasks with different module names can be called from single execution. In addition, same module name can be used in multiple tasks.
 
-**JSON:**
+JSON:
 
 ```json
 {
@@ -169,7 +169,7 @@ Sample module input file with multiple tasks. Tasks with different module names 
 }
 ```
 
-**YAML:**
+YAML:
 
 ```yaml
 tasks:
@@ -197,7 +197,7 @@ BBBBBBBBBB,AP2,0.0.0.0
 
 2. Create an input JSON file for the rename_ap module.
 
-**JSON:**
+JSON:
 
 ```json
 {
@@ -211,7 +211,7 @@ BBBBBBBBBB,AP2,0.0.0.0
 }
 ```
 
-**YAML:**
+YAML:
 
 ```yaml
 tasks:
@@ -265,7 +265,7 @@ This module is built to make any HTTP request Aruba Central has to offer. It bas
 
 Input Paramerts to tasks list is as follow,
 
-**JSON:**
+JSON:
 
 ```json
 {
@@ -285,7 +285,7 @@ Input Paramerts to tasks list is as follow,
 }
 ```
 
-**YAML:**
+YAML:
 ```yaml
 tasks:
   - api_request:

--- a/rest-api-python-scripts/central_modules/api_request/sample_input.yaml
+++ b/rest-api-python-scripts/central_modules/api_request/sample_input.yaml
@@ -1,0 +1,25 @@
+tasks:
+  - api_request:
+      description: "Get group list"
+      api_path: "/configuration/v2/groups"
+      api_params:
+        limit: 20
+        offset: 0
+      api_method: "GET"
+
+  - api_request:
+      description: "Create a template group named auto-group-py"
+      api_path: "/configuration/v2/groups"
+      api_method: "POST"
+      api_data:
+        group: "auto-group-py"
+        group_attributes:
+          group_password: "admin1234"
+          template_info:
+            Wired: true
+            Wireless: true
+
+  - api_request:
+      description: "Delete a template group named auto-group-py"
+      api_path: "/configuration/v1/groups/auto-group-py"
+      api_method: "DELETE"

--- a/rest-api-python-scripts/central_modules/execute_module.py
+++ b/rest-api-python-scripts/central_modules/execute_module.py
@@ -46,8 +46,14 @@ if __name__ == "__main__":
     token_store = None
     if "token_store" in inventory_args:
         token_store = inventory_args["token_store"]
+
+    ssl_verify = True
+    if "ssl_verify" in inventory_args:
+        ssl_verify = inventory_args["ssl_verify"]
+
     central_logger = utils.console_logger("ARUBA_CENTRAL_BASE")
-    central_conn = ArubaCentralBase(central_info, token_store, central_logger)
+    central_conn = ArubaCentralBase(central_info, token_store, central_logger,
+                                    ssl_verify=ssl_verify)
 
     # Get sub-directory list of current dir
     dir_list = utils.get_subdir_list(dir_name='.', with_path=False)

--- a/rest-api-python-scripts/central_modules/input_credentials.json
+++ b/rest-api-python-scripts/central_modules/input_credentials.json
@@ -11,5 +11,6 @@
   "token_store": {
     "type": "local",
     "path": "temp"
-  }
+  },
+  "ssl_verify": true
 }

--- a/rest-api-python-scripts/central_modules/input_credentials.yaml
+++ b/rest-api-python-scripts/central_modules/input_credentials.yaml
@@ -1,0 +1,12 @@
+lib_path: "../"
+central_info:
+  username: "<aruba-central-account-username>"
+  password: "<aruba-central-account-password>"
+  client_id: "<api-gateway-client-id>"
+  client_secret: "<api-gateway-client-secret>"
+  customer_id: "<aruba-central-customer-id>"
+  base_url: "<api-gateway-domain-url>"
+token_store:
+  type: "local"
+  path: "temp"
+ssl_verify: true

--- a/rest-api-python-scripts/central_modules/input_token_only.json
+++ b/rest-api-python-scripts/central_modules/input_token_only.json
@@ -5,5 +5,6 @@
                 "token": {
                   "access_token": "<api-gateway-access-token>"
                 }
-               }
+              },
+  "ssl_verify": true
 }

--- a/rest-api-python-scripts/central_modules/module_utils.py
+++ b/rest-api-python-scripts/central_modules/module_utils.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import json
+import json, yaml
 import logging
 import glob
 from os.path import dirname, basename, isfile, join
@@ -70,7 +70,14 @@ def get_file_content(file_name):
     input_args = ""
     try:
         with open(file_name, "r") as fp:
-            input_args = json.loads(fp.read())
+            file_dummy, file_ext = os.path.splitext(file_name)
+            if ".json" in file_ext:
+                input_args = json.loads(fp.read())
+            elif file_ext in ['.yaml', '.yml']:
+                input_args = yaml.safe_load(fp.read())
+            else:
+                raise UserWarning("Provide valid inventory file "
+                                  "format/extension [.json/.yaml/.yml]!")
         return input_args
     except Exception as err:
         exit("exiting.. Unable to open file " + \

--- a/rest-api-python-scripts/central_modules/rename_ap/task_input.yaml
+++ b/rest-api-python-scripts/central_modules/rename_ap/task_input.yaml
@@ -1,0 +1,3 @@
+tasks:
+  - rename_ap:
+      ap_info: "rename_ap/csv_file.csv"


### PR DESCRIPTION
1) Move oauth 2.0 API requests from urllib to requests package.
2) Add option for SSL cert validation, so the user can decide if not to verify SSL cert.
3) The scripts now accept both JSON and YAML input files.
4) Update documentation
