### PR TITLE
Hostnames system info patch

### DIFF
--- a/rename-hostnames/README.md
+++ b/rename-hostnames/README.md
@@ -1,14 +1,17 @@
 # Rename Hostnames
-This workflow uses the PyCentral SDK to automate configuring hostname profiles of
-devices in Central. The workflow first checks the device serial numbers against Central
-to verify devices are ready to be provisioned. Then, device hostname profiles are either
-created or updated determined by their current hostname status. The workflow will also
-create a CSV output file containing the status of hostname configuration operations.
+This workflow uses the PyCentral SDK to automate configuring the hostname of devices in
+Central. The workflow first checks the device serial numbers against Central to verify
+devices are ready to be configured. Then, device hostnames are either created or 
+updated determined by their current System Information profile status. Only the default 
+System Information profile will be updated. In the case where there are no current
+profiles, one will be created with the default profile name of "sys-system-info-profile"
+The workflow will also create a CSV output file containing the status of hostname
+configuration operations.
 
 ## Prerequisites
 - Python 3.8 or higher
 - API credentials for HPE Aruba Networking Central(YAML format)
-- All target devices are ready for provisioning in Central
+- All target devices are provisioned and configuration ready
 
 ## Installation
 

--- a/rename-hostnames/README.md
+++ b/rename-hostnames/README.md
@@ -31,7 +31,7 @@ source venv/bin/activate  # On Windows use: venv\Scripts\activate
 pip install -r requirements.txt
 ```
 
-_This workflow is tested on the PyCentral SDK (version: 2.0a16). Please check compatibility before executing on older/newer versions as there may be changes_
+_This workflow is tested on the PyCentral SDK (version: 2.0a21). Please check compatibility before executing on older/newer versions as there may be changes_
 
 ## Configuration
 

--- a/rename-hostnames/rename_hostnames.py
+++ b/rename-hostnames/rename_hostnames.py
@@ -152,6 +152,12 @@ def checking_devices(scope, serial_number):
             f"  {colored('Error', 'red')}: Device {colored(serial_number, 'blue')} not provisioned in Central.\n"
         )
         status.append("failure")
+    elif not device_function:
+        spinner.fail()
+        print(
+            f"  {colored('Error', 'red')}: Device {colored(serial_number, 'blue')} has no persona assigned.\n"
+        )
+        status.append("failure")
     else:
         spinner.succeed()
         print(

--- a/rename-hostnames/rename_hostnames.py
+++ b/rename-hostnames/rename_hostnames.py
@@ -14,7 +14,7 @@ serial_numbers = []
 new_hostnames = []
 device_functions = []
 status = []
-sys_info_path = generate_url("system-info")
+sys_info_path = generate_url("system-info/sys-system-info-profile")
 
 
 def define_arguments():

--- a/rename-hostnames/requirements.txt
+++ b/rename-hostnames/requirements.txt
@@ -1,2 +1,2 @@
 halo==0.0.31
-pycentral==2.0a16
+pycentral==2.0a21


### PR DESCRIPTION
Patch for rename hostnames to fix issues introduced in the recent API changes. This patch updates the system-info endpoint to add the default system info profile name to the path. Additionally, updates requirements PyCentral version to use the latest version which included a fix related to device functions that is required for the script.